### PR TITLE
Require jest-config as package

### DIFF
--- a/packages/is-even/jest.config.js
+++ b/packages/is-even/jest.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  ...require("../jest-config"),
+  ...require("@my-monorepo/jest-config"),
 };

--- a/packages/is-odd/jest.config.js
+++ b/packages/is-odd/jest.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  ...require("../jest-config"),
+  ...require("@my-monorepo/jest-config"),
 };

--- a/packages/server/jest.config.js
+++ b/packages/server/jest.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  ...require("../jest-config"),
+  ...require("@my-monorepo/jest-config"),
 };


### PR DESCRIPTION
Require the jest-config package in the same way as the eslint-config package.